### PR TITLE
ci/feature/MRTI-5256

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = [
 
 [dependencies]
 reqwest = { version = "0.11", features = ["blocking", "json"] }
+openssl = { version = "0.10", features = ["vendored"] }
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.48"
 config = "0.13.1"


### PR DESCRIPTION
Our crate ocd-datalake-rs used by Datalake Hunter depends on openssl. To simplify the release process, we are using the cross  compilation tools [GitHub - cross-rs/cross: “Zero setup” cross compilation and “cross testing” of Rust crates](https://github.com/cross-rs/cross) , however the images used by cross do not have openssl installed by default, leading to failed build for the linux platform.

To fix this issue, we should add openssl as an explicit dependency. This prevents the fail to build if openssl is not installed on the build machine.